### PR TITLE
Repair RStudio add-in

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,6 +31,7 @@ Encoding: UTF-8
 LazyData: true
 Suggests: 
     bookdown,
+    clipr,
     covr,
     covrpage,
     mockery,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,14 +30,15 @@ License: GPL-3
 Encoding: UTF-8
 LazyData: true
 Suggests: 
+    bookdown,
     covr,
     covrpage,
-    testthat,
-    xaringan,
-    tufte,
-    bookdown,
+    mockery,
     revealjs,
-    mockery
+    shinyFiles,
+    testthat,
+    tufte,
+    xaringan
 VignetteBuilder: knitr
 Imports: 
     devtools,

--- a/R/shinyGadget.R
+++ b/R/shinyGadget.R
@@ -8,7 +8,7 @@ projectGadget <- function() {
   ui <- miniUI::miniPage(
     miniUI::gadgetTitleBar("Create Project"),
     miniUI::miniContentPanel(
-      shiny::tags$style("#folder {width: 435px; };",
+      shiny::tags$style("#folder {width: 210px; };",
         type = "text/css"
       ),
       # Custom shiny to javascript binding
@@ -28,24 +28,30 @@ projectGadget <- function() {
           choices = c("Basic", "Package", "Analysis", "Training"),
           selected = "Basic"
         ),
-        shiny::selectInput(
-          "initial_status",
-          label = "Initial Status",
-          choices = statuses()$status,
-          selected = "wip"
+        shiny::tags$div(
+          title = "A badge from repostatus.org will be added to the README.",
+          shiny::selectInput(
+            "initial_status",
+            label = "Initial Status",
+            choices = statuses()$status,
+            selected = "wip"
+          )
         ),
-        shiny::textInput("name", "Project Name", value = NULL),
-        shiny::textInput("title", "Project Title", value = NULL),
+        shiny::tags$div(
+          title = "This will be used as the name for the project.",
+          shiny::textInput("name", "Project Name", value = NULL)
+        ),
+        shiny::tags$div(
+          title = "A description of what the project does.",
+          shiny::textInput("title", "Project Title", value = NULL)
+        ),
         shiny::div("Project Folder", class = "control-label", style = "font-weight: bold;"),
-        shiny::br(),
-        shiny::br(),
         shiny::br(),
         shinyFiles::shinyDirButton("folder",
           label = "Choose Folder",
           title = "Please choose a project folder",
           class = "btn-primary"
         ),
-        shiny::br(),
         shiny::uiOutput("folder")
       ),
       shiny::uiOutput("ui"),
@@ -139,9 +145,6 @@ projectGadget <- function() {
             selected = c("data", "analysis", "output"),
             multiple = TRUE
           ),
-          shiny::br(),
-          shiny::br(),
-          shiny::br(),
           shiny::radioButtons("packagedeps",
             label = "Dependency Management",
             choices = okpackagedeps(),
@@ -155,7 +158,7 @@ projectGadget <- function() {
             shiny::checkboxInput("reset", "Reset Project", value = TRUE)
           ),
           shiny::checkboxInput("externalSetup", label = "External Setup", value = FALSE),
-          shiny::checkboxInput("bestPractices", label = "Run additional best practice commands", value = TRUE),
+          shiny::br(),
           shiny::radioButtons("coverage",
             label = "Code Coverage",
             choices = c("codecov", "coveralls"),
@@ -180,9 +183,6 @@ projectGadget <- function() {
             selected = c("data", "handouts", "slides"),
             multiple = TRUE
           ),
-          shiny::br(),
-          shiny::br(),
-          shiny::br(),
           shiny::radioButtons("packagedeps",
             label = "Dependency Management",
             choices = okpackagedeps(),
@@ -235,7 +235,6 @@ projectGadget <- function() {
           title = empty_as_null(input$title),
           folder = folder(),
           initial_status = input$initial_status,
-          bestPractices = input$bestPractices,
           coverage = input$coverage,
           git = input$git,
           pkgdown = input$pkgdown,
@@ -260,7 +259,5 @@ projectGadget <- function() {
     })
   }
 
-  shiny::runGadget(
-    ui, server
-  )
+  shiny::runGadget(ui, server)
 }

--- a/R/shinyGadget.R
+++ b/R/shinyGadget.R
@@ -5,6 +5,12 @@ projectGadget <- function() {
     )
   }
 
+  if (!requireNamespace("clipr", quietly = TRUE)) {
+    stop("The clipr package is required for this gadget to work. Please install it.",
+         call. = FALSE
+    )
+  }
+
   ui <- miniUI::miniPage(
     miniUI::gadgetTitleBar("Create Project"),
     miniUI::miniContentPanel(
@@ -13,7 +19,7 @@ projectGadget <- function() {
       ),
       # Custom shiny to javascript binding
       # scrolls "content" to bottom once called
-      tags$script(
+      shiny::tags$script(
         "Shiny.addCustomMessageHandler('scrollCallback',
           function(x) {
             var content = document.getElementsByClassName('gadget-scroll')[0];
@@ -207,53 +213,61 @@ projectGadget <- function() {
 
       switch(input$projectType,
 
-        "Basic" = createBasicProject(
-          name = input$name,
-          title = empty_as_null(input$title),
-          folder = folder(),
-          initial_status = input$initial_status,
-          packagedeps = input$packagedeps,
-          git = input$git,
-          external_setup = ext_setup(input),
-          reset = input$reset
+        "Basic" = capture(
+          call("createBasicProject",
+            name = input$name,
+            title = empty_as_null(input$title),
+            folder = as.character(folder()),
+            initial_status = input$initial_status,
+            packagedeps = input$packagedeps,
+            git = input$git,
+            external_setup = ext_setup(input),
+            reset = input$reset
+          )
         ),
 
-        "Analysis" = createAnalysisProject(
-          name = input$name,
-          title = empty_as_null(input$title),
-          folder = folder(),
-          initial_status = input$initial_status,
-          dirs = input$dirs,
-          git = input$git,
-          packagedeps = input$packagedeps,
-          external_setup = ext_setup(input),
-          reset = input$reset
+        "Analysis" = capture(
+          call("createAnalysisProject",
+            name = input$name,
+            title = empty_as_null(input$title),
+            folder = as.character(folder()),
+            initial_status = input$initial_status,
+            dirs = input$dirs,
+            git = input$git,
+            packagedeps = input$packagedeps,
+            external_setup = ext_setup(input),
+            reset = input$reset
+          )
         ),
 
-        "Package" = createPackageProject(
-          name = input$name,
-          title = empty_as_null(input$title),
-          folder = folder(),
-          initial_status = input$initial_status,
-          coverage = input$coverage,
-          git = input$git,
-          pkgdown = input$pkgdown,
-          external_setup = ext_setup(input),
-          reset = input$reset
+        "Package" = capture(
+          call("createPackageProject",
+            name = input$name,
+            title = empty_as_null(input$title),
+            folder = as.character(folder()),
+            initial_status = input$initial_status,
+            coverage = input$coverage,
+            git = input$git,
+            pkgdown = input$pkgdown,
+            external_setup = ext_setup(input),
+            reset = input$reset
+          )
         ),
 
-        "Training" = createTrainingProject(
-          name = input$name,
-          title = empty_as_null(input$title),
-          folder = folder(),
-          initial_status = input$initial_status,
-          dirs = input$dirs,
-          handoutEngine = input$handoutE,
-          slideEngine = input$slideE,
-          git = input$git,
-          packagedeps = input$packagedeps,
-          external_setup = ext_setup(input),
-          reset = input$reset
+        "Training" = capture(
+          call("createTrainingProject",
+            name = input$name,
+            title = empty_as_null(input$title),
+            folder = as.character(folder()),
+            initial_status = input$initial_status,
+            dirs = input$dirs,
+            handoutEngine = input$handoutE,
+            slideEngine = input$slideE,
+            git = input$git,
+            packagedeps = input$packagedeps,
+            external_setup = ext_setup(input),
+            reset = input$reset
+          )
         )
       )
     })

--- a/R/shinyGadget.R
+++ b/R/shinyGadget.R
@@ -1,64 +1,163 @@
 projectGadget <- function() {
+
+  if (!requireNamespace("shinyFiles", quietly = TRUE)) {
+    stop("The shinyFiles package is required for this gadget to work. Please install it.",
+         call. = FALSE)
+  }
+
   ui <- miniUI::miniPage(
     miniUI::gadgetTitleBar("Create pRoject"),
     miniUI::miniContentPanel(
+      shiny::tags$style("#folder {width: 435px; };",
+        type = "text/css"
+      ),
       shiny::inputPanel(
         shiny::selectInput(
           "projectType",
           label = "Project Type",
-          choices = c("Basic", "Analysis", "Package", "Training"),
+          choices = c("Basic", "Package", "Analysis", "Training"),
           selected = "Basic"
         ),
-        shiny::textInput("name", "Project Name")
+        shiny::selectInput(
+          "initial_status",
+          label = "Initial Status",
+          choices = statuses()$status,
+          selected = "wip"
+        ),
+        shiny::textInput("name", "Project Name", value = NULL),
+        shiny::textInput("title", "Project Title", value = NULL),
+        shiny::div("Project Folder", class = "control-label", style = "font-weight: bold;"),
+        shiny::br(),
+        shiny::br(),
+        shiny::br(),
+        shinyFiles::shinyDirButton("folder",
+          label = "Choose Folder",
+          title = "Please select a folder",
+          class = "btn-primary"
+        ),
+        shiny::br(),
+        shiny::uiOutput("folder")
       ),
       shiny::uiOutput("ui"),
       shiny::conditionalPanel(
-        condition = "input.projectType != 'Package'",
+        condition = "input.externalSetup",
         shiny::inputPanel(
-          shiny::h4("Best Practices"),
-          shiny::br(),
-          shiny::checkboxInput("git", "Use Git", value = TRUE),
-          shiny::checkboxInput("travis", "Use Travis", value = TRUE),
-          shiny::selectInput("packagedeps",
-            label = "Use a package for handling reproducibility",
-            choices = c("none", "packrat", "checkpoint"),
-            selected = "packrat"
-          )
+          shiny::radioButtons("git_service",
+                              label = "Git Service",
+                              choices = "GitHub"
+          ),
+          shiny::radioButtons("private", label = "Repository",
+            choices = c("public" = FALSE, "private" = TRUE)
+          ),
+          shiny::radioButtons("protocol",
+            label = "Protocol",
+            choices = c("ssh", "http"),
+            select = "ssh"
+          ),
+          shiny::radioButtons("ci_activation",
+            label = "Continuous Integration",
+            choices = c("none"="", "travis")
+          ),
+          shiny::textInput("login", label = "Login", value = gh::gh_whoami()$login)
         )
       )
     )
   )
 
   server <- function(input, output, session) {
+    volumes <- c(
+      Home = fs::path_home(),
+      "R Installation" = R.home(),
+      shinyFiles::getVolumes()()
+    )
+
+    shinyFiles::shinyDirChoose(
+      input, "folder",
+      roots = volumes, session = session,
+      restrictions = system.file(package = "base")
+    )
+
+    folder <- shiny::reactive({
+      folder <- shinyFiles::parseDirPath(volumes, input$folder)
+      if (length(folder) == 0) {
+        folder <- getwd()
+      }
+      folder
+    })
+
+    output$folder <- shiny::renderUI({
+      shiny::textInput("folder", NULL,
+        value = folder()
+      )
+    })
+
     output$ui <- shiny::renderUI({
       switch(input$projectType,
 
-        "Basic" = shiny::div(),
+        "Basic" = shiny::inputPanel(
+          shiny::checkboxInput("git", "Use Git", value = TRUE),
+          shiny::checkboxInput("reset", "Reset Project", value = TRUE),
+          shiny::checkboxInput("externalSetup", label = "External Setup", value = FALSE),
+          shiny::br(),
+          shiny::radioButtons("packagedeps",
+            label = "Dependency Management",
+            choices = okpackagedeps(),
+            selected = "checkpoint"
+          )
+        ),
         "Analysis" = shiny::inputPanel(
+          shiny::checkboxInput("git", "Use Git", value = TRUE),
+          shiny::checkboxInput("reset", "Reset Project", value = TRUE),
+          shiny::checkboxInput("externalSetup", label = "External Setup", value = FALSE),
+          shiny::br(),
           shiny::selectInput("dirs",
             label = "Directories",
             choices = c("data", "analysis", "output"),
             selected = c("data", "analysis", "output"),
             multiple = TRUE
+          ),
+          shiny::br(),
+          shiny::br(),
+          shiny::br(),
+          shiny::radioButtons("packagedeps",
+            label = "Dependency Management",
+            choices = okpackagedeps(),
+            selected = "checkpoint"
           )
         ),
         "Package" = shiny::inputPanel(
-          shiny::h4("Best Practice"),
-          shiny::br(),
-          shiny::br(),
-          shiny::conditionalPanel(
-            shiny::selectInput("coverage",
-              label = "Code Coverage",
-              choices = c("codecov", "coveralls")
-            )
+          shiny::checkboxInput("git", "Use Git", value = TRUE),
+          shiny::checkboxInput("reset", "Reset Project", value = TRUE),
+          shiny::checkboxInput("externalSetup", label = "External Setup", value = FALSE),
+          shiny::checkboxInput("bestPractices", label = "Run additional best practice commands", value = TRUE),
+          shiny::radioButtons("coverage",
+            label = "Code Coverage",
+            choices = c("codecov", "coveralls"),
+            selected = "codecov"
+          ),
+          shiny::radioButtons("pkgdown",
+            label = "Add pkgdown config",
+            choices = c("Yes" = TRUE, "No" = FALSE)
           )
         ),
         "Training" = shiny::inputPanel(
+          shiny::checkboxInput("git", "Use Git", value = TRUE),
+          shiny::checkboxInput("reset", "Reset Project", value = TRUE),
+          shiny::checkboxInput("externalSetup", label = "External Setup", value = FALSE),
+          shiny::br(),
           shiny::selectInput("dirs",
             label = "Directories",
             choices = c("data", "handouts", "slides"),
             selected = c("data", "handouts", "slides"),
             multiple = TRUE
+          ),
+          shiny::br(),
+          shiny::br(),
+          shiny::br(),
+          shiny::radioButtons("packagedeps",
+            label = "Dependency Management",
+            choices = okpackagedeps(),
+            selected = "checkpoint"
           ),
           shiny::radioButtons("handoutE",
             label = "Handouts",
@@ -75,37 +174,65 @@ projectGadget <- function() {
     })
 
     shiny::observeEvent(input$done, {
+      shiny::stopApp()
+
       switch(input$projectType,
 
         "Basic" = createBasicProject(
           name = input$name,
+          title = empty_as_null(input$title),
+          folder = folder(),
+          initial_status = input$initial_status,
+          packagedeps = input$packagedeps,
           git = input$git,
-          packagedeps = input$packagedeps
+          external_setup = ext_setup(input),
+          reset = input$reset
         ),
 
         "Analysis" = createAnalysisProject(
-          name = input$name, dirs = input$dirs,
+          name = input$name,
+          title = empty_as_null(input$title),
+          folder = folder(),
+          initial_status = input$initial_status,
+          dirs = input$dirs,
           git = input$git,
-          packagedeps = input$packagedeps
+          packagedeps = input$packagedeps,
+          external_setup = ext_setup(input),
+          reset = input$reset
         ),
 
         "Package" = createPackageProject(
           name = input$name,
-          coverage = input$coverage
+          title = empty_as_null(input$title),
+          folder = folder(),
+          initial_status = input$initial_status,
+          bestPractices = input$bestPractices,
+          coverage = input$coverage,
+          git = input$git,
+          pkgdown = input$pkgdown,
+          external_setup = ext_setup(input),
+          reset = input$reset
         ),
 
         "Training" = createTrainingProject(
-          name = input$name, dirs = input$dirs,
+          name = input$name,
+          title = empty_as_null(input$title),
+          folder = folder(),
+          initial_status = input$initial_status,
+          dirs = input$dirs,
           handoutEngine = input$handoutE,
           slideEngine = input$slideE,
           git = input$git,
-          packagedeps = input$packagedeps
+          packagedeps = input$packagedeps,
+          external_setup = ext_setup(input),
+          reset = input$reset
         )
       )
-
-      shiny::stopApp()
     })
   }
 
-  shiny::runGadget(ui, server)
+  shiny::runGadget(
+    ui, server,
+    viewer = shiny::dialogViewer("pRojects", width = 1000)
+  )
 }

--- a/R/shinyGadget.R
+++ b/R/shinyGadget.R
@@ -11,6 +11,16 @@ projectGadget <- function() {
       shiny::tags$style("#folder {width: 435px; };",
         type = "text/css"
       ),
+      # Custom shiny to javascript binding
+      # scrolls "content" to bottom once called
+      tags$script(
+        "Shiny.addCustomMessageHandler('scrollCallback',
+          function(x) {
+            var content = document.getElementsByClassName('gadget-scroll')[0];
+            content.scrollTop = content.scrollHeight - content.clientHeight;
+          }
+        );"
+      ),
       shiny::inputPanel(
         shiny::selectInput(
           "projectType",
@@ -66,6 +76,12 @@ projectGadget <- function() {
   )
 
   server <- function(input, output, session) {
+
+    # Call custom javascript to scroll window
+    observeEvent(input$externalSetup,
+      if(input$externalSetup) session$sendCustomMessage(type = "scrollCallback", 1)
+    )
+
     volumes <- c(
       "Working Directory" = getwd(),
       Home = fs::path_home(),

--- a/R/shinyGadget.R
+++ b/R/shinyGadget.R
@@ -1,12 +1,12 @@
 projectGadget <- function() {
-
   if (!requireNamespace("shinyFiles", quietly = TRUE)) {
     stop("The shinyFiles package is required for this gadget to work. Please install it.",
-         call. = FALSE)
+      call. = FALSE
+    )
   }
 
   ui <- miniUI::miniPage(
-    miniUI::gadgetTitleBar("Create pRoject"),
+    miniUI::gadgetTitleBar("Create Project"),
     miniUI::miniContentPanel(
       shiny::tags$style("#folder {width: 435px; };",
         type = "text/css"
@@ -32,7 +32,7 @@ projectGadget <- function() {
         shiny::br(),
         shinyFiles::shinyDirButton("folder",
           label = "Choose Folder",
-          title = "Please select a folder",
+          title = "Please choose a project folder",
           class = "btn-primary"
         ),
         shiny::br(),
@@ -43,10 +43,11 @@ projectGadget <- function() {
         condition = "input.externalSetup",
         shiny::inputPanel(
           shiny::radioButtons("git_service",
-                              label = "Git Service",
-                              choices = "GitHub"
+            label = "Git Service",
+            choices = "GitHub"
           ),
-          shiny::radioButtons("private", label = "Repository",
+          shiny::radioButtons("private",
+            label = "Repository",
             choices = c("public" = FALSE, "private" = TRUE)
           ),
           shiny::radioButtons("protocol",
@@ -56,7 +57,7 @@ projectGadget <- function() {
           ),
           shiny::radioButtons("ci_activation",
             label = "Continuous Integration",
-            choices = c("none"="", "travis")
+            choices = c("none" = "", "travis")
           ),
           shiny::textInput("login", label = "Login", value = gh::gh_whoami()$login)
         )
@@ -66,8 +67,8 @@ projectGadget <- function() {
 
   server <- function(input, output, session) {
     volumes <- c(
+      "Working Directory" = getwd(),
       Home = fs::path_home(),
-      "R Installation" = R.home(),
       shinyFiles::getVolumes()()
     )
 
@@ -96,7 +97,10 @@ projectGadget <- function() {
 
         "Basic" = shiny::inputPanel(
           shiny::checkboxInput("git", "Use Git", value = TRUE),
-          shiny::checkboxInput("reset", "Reset Project", value = TRUE),
+          shiny::tags$div(
+            title = "This will reset the active RStudio project after setup completes",
+            shiny::checkboxInput("reset", "Reset Project", value = TRUE)
+          ),
           shiny::checkboxInput("externalSetup", label = "External Setup", value = FALSE),
           shiny::br(),
           shiny::radioButtons("packagedeps",
@@ -107,7 +111,10 @@ projectGadget <- function() {
         ),
         "Analysis" = shiny::inputPanel(
           shiny::checkboxInput("git", "Use Git", value = TRUE),
-          shiny::checkboxInput("reset", "Reset Project", value = TRUE),
+          shiny::tags$div(
+            title = "This will reset the active RStudio project after setup completes",
+            shiny::checkboxInput("reset", "Reset Project", value = TRUE)
+          ),
           shiny::checkboxInput("externalSetup", label = "External Setup", value = FALSE),
           shiny::br(),
           shiny::selectInput("dirs",
@@ -127,7 +134,10 @@ projectGadget <- function() {
         ),
         "Package" = shiny::inputPanel(
           shiny::checkboxInput("git", "Use Git", value = TRUE),
-          shiny::checkboxInput("reset", "Reset Project", value = TRUE),
+          shiny::tags$div(
+            title = "This will reset the active RStudio project after setup completes",
+            shiny::checkboxInput("reset", "Reset Project", value = TRUE)
+          ),
           shiny::checkboxInput("externalSetup", label = "External Setup", value = FALSE),
           shiny::checkboxInput("bestPractices", label = "Run additional best practice commands", value = TRUE),
           shiny::radioButtons("coverage",
@@ -142,7 +152,10 @@ projectGadget <- function() {
         ),
         "Training" = shiny::inputPanel(
           shiny::checkboxInput("git", "Use Git", value = TRUE),
-          shiny::checkboxInput("reset", "Reset Project", value = TRUE),
+          shiny::tags$div(
+            title = "This will reset the active RStudio project after setup completes",
+            shiny::checkboxInput("reset", "Reset Project", value = TRUE)
+          ),
           shiny::checkboxInput("externalSetup", label = "External Setup", value = FALSE),
           shiny::br(),
           shiny::selectInput("dirs",
@@ -232,7 +245,6 @@ projectGadget <- function() {
   }
 
   shiny::runGadget(
-    ui, server,
-    viewer = shiny::dialogViewer("pRojects", width = 1000)
+    ui, server
   )
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -163,3 +163,30 @@ gh_retry <- function(quoted_expression){
   }
   return(ok)
 }
+
+#####################################
+# Process inputs in shiny gadget
+#####################################
+
+#' Treat empty string as NULL
+#' @noRd
+empty_as_null <- function(arg) {
+  if(arg == "") return(NULL)
+  arg
+}
+
+#' Create config list for external_setup
+#' @noRd
+ext_setup <- function(input) {
+  if(!input$externalSetup) {
+    NULL
+  } else {
+    list(
+      git_service = input$git_service,
+      private = input$private,
+      protocol = input$protocol,
+      login = input$login,
+      ci_activation = ifelse(input$ci_activation == "", NULL, input$ci_activation)
+    )
+  }
+}

--- a/R/utils.R
+++ b/R/utils.R
@@ -190,3 +190,15 @@ ext_setup <- function(input) {
     )
   }
 }
+
+#' Capture expression, write to clipboard, evaluate & output as message
+#' @noRd
+capture <- function(x) {
+  str_x <- deparse(x)
+  eval(x)
+  message(
+    "The starters function call is shown below and has been copied to the clipboard:\n\n",
+    str_x
+  )
+  clipr::write_clip(str_x)
+}


### PR DESCRIPTION
To address #71 

<img width="1026" alt="projects-add-in" src="https://user-images.githubusercontent.com/5055818/50561557-87c74000-0d14-11e9-96b2-b6d2c718f85a.png">

Hopefully this will make the add-in functional again following all the breaking changes introduced earlier in the year.

I imagine this will need some review and iteration (and is subject to outstanding changes such as those in #100 which I am assuming will be accepted), so it's WIP for now.

Working on this seems to keep highlighting little issues - which I suppose is a good thing but rather frustrating, since these are tangential and interrupt progress, especially when only looking at it every now and again in one's spare time. Anyway, I felt I just had to open this PR before the end of the year since I first agreed to fix the add-in 2 months ago 🙈

I've changed to the modal dialog viewer in order to facilitate a bigger and better UI/layout. This is also required due to the introduction of shinyFiles (for selecting the project folder) which is not really useable within the smaller miniUI layouts (particularly within an RStudio pane) without having to scroll vertically.

<img width="1440" alt="projects-add-in-select-folder" src="https://user-images.githubusercontent.com/5055818/50561626-1b007580-0d15-11e9-8346-c89516db6eba.png">

The downside of this is that the modal stays open and partially obscures the terminal (after clicking done) until whichever `createProject()` function was selected has finished running. Due to the interactive nature of `usethis`, one usually needs to confirm or make a few terminal selections as the functions are executed, so one has to manually close the shiny modal in order to do so.

Can anyone think of a workaround for this? We could try sticking to the smaller UI within the RStudio viewer pane, but it will then require some vertical scrolling to use since the input widgets (especially for shinyFiles) can't really be forced into such a narrow / small space (example shown below).

![projects-viewer-pane](https://user-images.githubusercontent.com/5055818/50562138-2a35f200-0d1a-11e9-98e6-f8e69c0ca0d1.gif)

As always am happy to accept any feedback, criticism, or suggestions on this.